### PR TITLE
Drools test support class, while adding Test Drool file content to KI…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.jeichler</groupId>
 	<artifactId>junit-drools</artifactId>
-	<version>1.0</version>
+	<version>1.0.1</version>
 	<packaging>jar</packaging>
 
 	<description>library for unit-testing drools rules</description>
@@ -12,7 +12,7 @@
 	<url>http://github.com/jeichler/junit-drools</url>
 
 	<properties>
-		<drools.version>6.2.0.Final</drools.version>
+		<drools.version>7.68.0.Final</drools.version>
 	</properties>
 
 	<dependencyManagement>

--- a/src/main/java/com/github/jeichler/junit/drools/DroolsTestSupport.java
+++ b/src/main/java/com/github/jeichler/junit/drools/DroolsTestSupport.java
@@ -14,7 +14,6 @@ import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.StatelessKieSession;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
@@ -49,11 +48,6 @@ class DroolsTestSupport {
             InputStream ruleFileIs = DroolsTestSupport.class.getResourceAsStream("/" + ruleFile);
             Assert.assertNotNull("Can't open stream for rule file. Does it exist?", ruleFileIs);
             kfs.write(ks.getResources().newInputStreamResource(ruleFileIs).setSourcePath(ruleFile));
-            try {
-                ruleFileIs.close();
-            } catch (IOException e) {
-                throw new RuntimeException("InputStream of rule file could not be closed.");
-            }
         }
         kieBuilder.buildAll();
 


### PR DESCRIPTION
Drools test support class, while adding Test Drool file content to KIE DB, closes the Drool file(s).  This lets to fail main drool compiler while reading file attributes.

Expecting, drools compiler will close the resources so that resource handler won't be dangling.

Main target is to make it compatible with drool-compiler 7.
